### PR TITLE
change-defaults-notification

### DIFF
--- a/extension/defaults.json
+++ b/extension/defaults.json
@@ -1,7 +1,7 @@
 {
     "options": {
         "badge": true,
-        "notification": false,
+        "notification": true,
         "max": 10,
         "ignore_no_changelogs": false
     },


### PR DESCRIPTION
i think notifications should be on by default so users know its there and its function and they can turn it off later if they choose. feel free to kill if you disagree.